### PR TITLE
Minor Data Fixes

### DIFF
--- a/timetrials/fixtures/players.json
+++ b/timetrials/fixtures/players.json
@@ -6440,7 +6440,7 @@
     "fields": {
         "user": null,
         "name": "Everett Vereen",
-        "region": 89,
+        "region": 307,
         "alias": null,
         "joined_date": "2024-09-07",
         "last_activity": null,
@@ -11835,7 +11835,7 @@
     "fields": {
         "user": null,
         "name": "Layne Stephens",
-        "region": 89,
+        "region": 307,
         "alias": null,
         "joined_date": "2024-09-07",
         "last_activity": null,
@@ -16515,7 +16515,7 @@
     "fields": {
         "user": null,
         "name": "Peyton Gunn",
-        "region": 89,
+        "region": 307,
         "alias": null,
         "joined_date": "2024-09-07",
         "last_activity": null,
@@ -20507,7 +20507,7 @@
         "user": null,
         "name": "Troy Howard",
         "region": 336,
-        "alias": "TWD98",
+        "alias": "Rhodechill",
         "joined_date": "2024-09-07",
         "last_activity": null,
         "bio": ""


### PR DESCRIPTION
- Fix Rhodechill Alias's being TWD98
- Fix a few Georgia (state) players ending up in Georgia (country)